### PR TITLE
Updating requirements.txt

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-openai
+openai==0.28.1
 PySimpleGUI==4.60.4
 sentence-transformers
 tqdm==4.64.1
@@ -25,7 +25,6 @@ wget==3.2
 pillow_heif
 pysqlite3
 plotly
-openai
 transformers
 faiss-cpu
 hydra-core==1.3.2

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@ sentence-transformers
 tqdm==4.64.1
 pytz
 timezonefinder
-torchvision==0.14.0
+torchvision==0.14.1
 torch==1.13.1
 scikit-learn==1.1.3
 numpy


### PR DESCRIPTION
The openai library now seems to use openai.embeddings instead of openai.Embedding (https://github.com/langchain-ai/langchain/issues/12954) and
bumped torchvision to 0.14.1. With torchvision 0.14.0 I had conflicts with torch==1.13.1 when building the docker container.