### PR TITLE
Fix customized promot not being used

### DIFF
--- a/notebooks/extract_narration_tutorial.ipynb
+++ b/notebooks/extract_narration_tutorial.ipynb
@@ -1592,7 +1592,7 @@
         "#os.environ[\"OPENAI_API_KEY\"] = \"sk-your-key\"\n",
         "PROMPT = PromptTemplate(template=prompt_template, input_variables=[\"text\"])\n",
         "llm = ChatOpenAI(temperature=0, model_name=\"gpt-3.5-turbo\")\n",
-        "chain = load_summarize_chain(llm, chain_type=\"stuff\")\n",
+        "chain = load_summarize_chain(llm, chain_type=\"stuff\", prompt=PROMPT)\n",
         "\n",
         "loader = CSVLoader(file_path=narration_save_path)\n",
         "docs = loader.load()\n",


### PR DESCRIPTION
Fix the problem that in the notebook the prompt is defined but not actually passed and used in LangChain.